### PR TITLE
Remove "save" dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "glob": "~7.1.2",
     "prop-types": "~15.5.10",
     "react": "~15.6.1",
-    "save": "~2.3.1",
     "yargs": "~9.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove the dependency for "save" since it is depending on event-stream/flatmap-stream which is a [compromised npm package](https://medium.com/intrinsic/compromised-npm-package-event-stream-d47d08605502).

If I am not mistaken, the "save" package is not used in this repo so removing it should have no effect.